### PR TITLE
Add app.config

### DIFF
--- a/src/NetMQ.WebSockets/app.config
+++ b/src/NetMQ.WebSockets/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="AsyncIO" publicKeyToken="44a94435bd6f33f8" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.1.69.0" newVersion="0.1.69.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>


### PR DESCRIPTION
I forgot to add app.config file, thus created compile issue. Sorry about that.

Two ways to fix:
1. Add app.config
2. Remove `<None Include="app.config" />` from NetMQ.WebSockets.csproj

Fix no. 1 I consider a better choice.